### PR TITLE
fix undefined access token

### DIFF
--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -43,15 +43,15 @@ class Auth extends Component {
         return;
       }
 
-      this.setSession(authResult.idTokenPayload);
+      this.setSession(authResult);
     });
   };
 
   setSession(data) {
     const user = {
-      id: data.sub,
-      email: data.email,
-      role: data[AUTH_CONFIG.roleUrl]
+      id: data.idTokenPayload.sub,
+      email: data.idTokenPayload.email,
+      role: data.idTokenPayload[AUTH_CONFIG.roleUrl]
     };
     this.setState({
       authenticated: true,


### PR DESCRIPTION
Thanks for the awesome tutorial about React RBAC + Auth0. The `Can` component is so neat and useful!

I noticed there was a minor bug when I was going through the tutorial related to the `accessToken`. Its value was `undefined` all the time so I made this fix.